### PR TITLE
Removed references to study and form titles in auditLogger

### DIFF
--- a/src/routes/forms.mjs
+++ b/src/routes/forms.mjs
@@ -52,7 +52,7 @@ export default async function () {
       newform = await db.createForm(newform)
       res.send(newform)
       applogger.info(newform, 'New form created')
-      auditLogger.log('formCreated', req.user._key, undefined, undefined, 'New form created ' + newform.name, 'forms', newform._key, newform)
+      auditLogger.log('formCreated', req.user._key, undefined, undefined, 'New form created', 'forms', newform._key, newform)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot store new form')
       res.sendStatus(500)
@@ -66,7 +66,7 @@ export default async function () {
       newform = await db.replaceForm(req.params.form_key, newform)
       res.send(newform)
       applogger.info(newform, 'Form has been replaced')
-      auditLogger.log('formReplaced', req.user._key, undefined, undefined, 'Form ' + newform.name + ' has been replaced', 'forms', newform._key, newform)
+      auditLogger.log('formReplaced', req.user._key, undefined, undefined, 'Form has been replaced', 'forms', newform._key, newform)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot replace form with _key ' + req.params.form_key)
       res.sendStatus(500)
@@ -80,7 +80,7 @@ export default async function () {
       newform = await db.updateForm(req.params.form_key, newform)
       res.send(newform)
       applogger.info(newform, 'Form has been updated')
-      auditLogger.log('formUpdate', req.user._key, undefined, undefined, 'Form ' + newform.name + ' has been updated', 'forms', newform._key, newform)
+      auditLogger.log('formUpdate', req.user._key, undefined, undefined, 'Form has been updated', 'forms', newform._key, newform)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot update form with _key ' + req.params.form_key)
       res.sendStatus(500)

--- a/src/routes/studies.mjs
+++ b/src/routes/studies.mjs
@@ -74,7 +74,7 @@ export default async function () {
       res.send(newstudy)
 
       applogger.info(newstudy, 'New study description added')
-      auditLogger.log('studyDescriptionAdded', req.user._key, newstudy._key, undefined, 'New study description added ' + newstudy.generalities.title, 'studies', newstudy._key, newstudy)
+      auditLogger.log('studyDescriptionAdded', req.user._key, newstudy._key, undefined, 'New study description added', 'studies', newstudy._key, newstudy)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot store new study')
       res.sendStatus(500)
@@ -90,7 +90,7 @@ export default async function () {
       newstudy = await db.replaceStudy(req.params.study_key, newstudy)
       res.send(newstudy)
       applogger.info(newstudy, 'Study replaced')
-      auditLogger.log('studyDescriptionReplaced', req.user._key, newstudy._key, undefined, 'Study description replaced ' + newstudy.generalities.title, 'studies', newstudy._key, newstudy)
+      auditLogger.log('studyDescriptionReplaced', req.user._key, newstudy._key, undefined, 'Study description replaced', 'studies', newstudy._key, newstudy)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot replace study with _key ' + req.params.study_key)
       res.sendStatus(500)
@@ -106,7 +106,7 @@ export default async function () {
       newstudy = await db.updateStudy(req.params.study_key, newstudy)
       res.send(newstudy)
       applogger.info(newstudy, 'Study updated')
-      auditLogger.log('studyDescriptionUpdated', req.user._key, newstudy._key, undefined, 'Study description updated ' + newstudy.generalities.title, 'studies', newstudy._key, newstudy)
+      auditLogger.log('studyDescriptionUpdated', req.user._key, newstudy._key, undefined, 'Study description updated', 'studies', newstudy._key, newstudy)
     } catch (err) {
       applogger.error({ error: err }, 'Cannot update study with _key ' + req.params.study_key)
       res.sendStatus(500)


### PR DESCRIPTION
Fixes an issue where the study and form messages in Audit Logs (Web/Admin) refer to `[object Object]` rather than the title of the study/form. The titles can be seen by clicking the **i**-button.

<img width="608" alt="Skärmavbild 2020-11-20 kl  13 44 36" src="https://user-images.githubusercontent.com/31319905/99801587-93a19280-2b36-11eb-8dae-ce7b19619092.png">
